### PR TITLE
feat: PostCategory 도메인 구현 및 테스트 추가 (Red-Green)

### DIFF
--- a/src/main/java/consome/domain/post/PostCategory.java
+++ b/src/main/java/consome/domain/post/PostCategory.java
@@ -1,0 +1,62 @@
+package consome.domain.post;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostCategory {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long boardId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    private PostCategory(Long boardId, String name, int displayOrder) {
+        this.boardId = boardId;
+        this.name = name;
+        this.displayOrder = displayOrder;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public static PostCategory create(Long boardId, String name, int displayOrder) {
+        return new PostCategory(boardId, name, displayOrder);
+    }
+
+    public void rename(String name) {
+        this.name = name;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void changeOrder(int displayOrder) {
+        this.displayOrder = displayOrder;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void delete() {
+        this.deleted = true;
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/test/java/consome/domain/post/PostCategoryTest.java
+++ b/src/test/java/consome/domain/post/PostCategoryTest.java
@@ -1,0 +1,54 @@
+package consome.domain.post;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostCategoryTest {
+
+    @Test
+    void 카테고리_생성_성공_tester() {
+        // given
+        Long boardId = 1L;
+        String name = "질문";
+        int order = 1;
+
+        // when
+        PostCategory category = PostCategory.create(boardId, name, order);
+
+        // then
+        assertThat(category.getBoardId()).isEqualTo(boardId);
+        assertThat(category.getName()).isEqualTo(name);
+        assertThat(category.getDisplayOrder()).isEqualTo(order);
+        assertThat(category.isDeleted()).isFalse();
+        assertThat(category.getCreatedAt()).isNotNull();
+        assertThat(category.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    void 카테고리_이름_수정_성공_tester() {
+        PostCategory category = PostCategory.create(1L, "질문", 1);
+
+        category.rename("정보");
+
+        assertThat(category.getName()).isEqualTo("정보");
+    }
+
+    @Test
+    void 카테고리_정렬순서_변경_성공_tester() {
+        PostCategory category = PostCategory.create(1L, "질문", 1);
+
+        category.changeOrder(2);
+
+        assertThat(category.getDisplayOrder()).isEqualTo(2);
+    }
+
+    @Test
+    void 카테고리_삭제_성공_tester() {
+        PostCategory category = PostCategory.create(1L, "질문", 1);
+
+        category.delete();
+
+        assertThat(category.isDeleted()).isTrue();
+    }
+}


### PR DESCRIPTION
- 게시글 카테고리 도메인(PostCategory) 생성
- 생성, 이름 변경, 정렬 순서 변경, 삭제 메서드 구현
- 논리 삭제 방식 적용
- PostCategoryTest 단위 테스트 작성 완료
- Post 도메인에 postCategoryId 필드 추가 및 테스트 반영
- 패키지 구조는 consome.domain.post로 정리