### PR TITLE
fix: Pagination max page size 100 제한

### DIFF
--- a/src/main/java/consome/infrastructure/config/WebConfig.java
+++ b/src/main/java/consome/infrastructure/config/WebConfig.java
@@ -1,12 +1,23 @@
 package consome.infrastructure.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+        resolver.setMaxPageSize(100);
+        resolvers.add(resolver);
+    }
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/uploads/**")

--- a/src/main/java/consome/interfaces/admin/v1/AdminV1SectionController.java
+++ b/src/main/java/consome/interfaces/admin/v1/AdminV1SectionController.java
@@ -68,7 +68,8 @@ public class AdminV1SectionController {
             @RequestParam(defaultValue = "20") int size,
             @RequestParam(required = false) String keyword,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
+        int safeSize = Math.min(size, 100);
         return ResponseEntity.ok(adminSectionFacade.findBoardsBySectionId(
-                sectionId, keyword, PageRequest.of(page, size), userDetails.getRole()));
+                sectionId, keyword, PageRequest.of(page, safeSize), userDetails.getRole()));
     }
 }


### PR DESCRIPTION
## 개요
클라이언트가 `?size=999999` 등으로 과도한 페이지 크기를 요청할 수 있는 보안 취약점 수정.

## 변경사항
- `WebConfig`에 `PageableHandlerMethodArgumentResolver.setMaxPageSize(100)` 글로벌 설정
- `AdminV1SectionController.findBoardsBySectionId()`: `PageRequest.of()` 직접 사용하므로 `Math.min(size, 100)` 별도 클램핑

## 테스트
- `?size=999999` 요청 → 실제 pageSize=100으로 클램핑 확인
- 전체 테스트 통과