### PR TITLE
fix: RedisConfig DefaultTyping 범위 축소 + Security Headers 추가

### DIFF
--- a/src/main/java/consome/infrastructure/config/RedisConfig.java
+++ b/src/main/java/consome/infrastructure/config/RedisConfig.java
@@ -51,9 +51,12 @@ public class RedisConfig {
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         objectMapper.activateDefaultTyping(
                 BasicPolymorphicTypeValidator.builder()
-                        .allowIfBaseType(Object.class)
+                        .allowIfSubType("consome.")
+                        .allowIfSubType("java.util.")
+                        .allowIfSubType("java.time.")
+                        .allowIfSubType("org.springframework.data.domain.")
                         .build(),
-                ObjectMapper.DefaultTyping.EVERYTHING,
+                ObjectMapper.DefaultTyping.NON_FINAL,
                 JsonTypeInfo.As.PROPERTY
         );
 

--- a/src/main/java/consome/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/consome/infrastructure/security/SecurityConfig.java
@@ -41,6 +41,11 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
         http
+                .headers(headers -> headers
+                        .frameOptions(frame -> frame.deny())
+                        .contentTypeOptions(content -> {})
+                        .cacheControl(cache -> {})
+                )
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
## 개요
보안 2차 점검에서 발견된 백엔드 취약점 2건 수정

## 변경사항

### 1. RedisConfig ObjectMapper DefaultTyping (Major)
- **문제**: `DefaultTyping.EVERYTHING` + `allowIfBaseType(Object.class)` → 임의 클래스 역직렬화 가능
- **수정**: `NON_FINAL`로 변경, `consome.*`, `java.util.*`, `java.time.*`, `org.springframework.data.domain.*`만 허용

### 2. Security Headers (Minor)
- **문제**: 보안 헤더 미설정
- **수정**: Spring Security headers 설정 추가
  - X-Frame-Options: DENY
  - X-Content-Type-Options: nosniff
  - Cache-Control: no-cache, no-store

## 테스트
- 전체 빌드/테스트 통과
- curl로 Security Headers 반환 확인