### PR TITLE
feat: SSE 일회용 연결 토큰으로 JWT URL 노출 방지

### DIFF
--- a/src/main/java/consome/application/notification/NotificationFacade.java
+++ b/src/main/java/consome/application/notification/NotificationFacade.java
@@ -5,8 +5,8 @@ import consome.domain.notification.NotificationService;
 import consome.domain.notification.NotificationType;
 import consome.domain.notification.repository.NotificationQueryRepository;
 import consome.domain.user.UserService;
-import consome.infrastructure.jwt.JwtProvider;
 import consome.infrastructure.notification.SseEmitterRepository;
+import consome.infrastructure.redis.SseTokenRedisRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -26,7 +26,7 @@ public class NotificationFacade {
     private final NotificationQueryRepository notificationQueryRepository;
     private final UserService userService;
     private final SseEmitterRepository sseEmitterRepository;
-    private final JwtProvider jwtProvider;
+    private final SseTokenRedisRepository sseTokenRedisRepository;
 
     public void notify(Long userId, NotificationType type, Long actorId,
                        Long targetId, Long relatedId, Long referenceId, String message) {
@@ -92,11 +92,13 @@ public class NotificationFacade {
         }
     }
 
+    public String createSseToken(Long userId) {
+        return sseTokenRedisRepository.createToken(userId);
+    }
+
     public SseEmitter subscribe(String token) {
-        if (!jwtProvider.validateToken(token)) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-        }
-        Long userId = jwtProvider.getUserId(token);
+        Long userId = sseTokenRedisRepository.consumeToken(token)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 SSE 토큰입니다."));
         return sseEmitterRepository.subscribe(userId);
     }
 }

--- a/src/main/java/consome/infrastructure/redis/SseTokenRedisRepository.java
+++ b/src/main/java/consome/infrastructure/redis/SseTokenRedisRepository.java
@@ -1,0 +1,48 @@
+package consome.infrastructure.redis;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+public class SseTokenRedisRepository {
+
+    private static final String KEY_PREFIX = "sse_token:";
+    private static final long TTL_SECONDS = 30;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Autowired(required = false)
+    public SseTokenRedisRepository(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public String createToken(Long userId) {
+        String token = UUID.randomUUID().toString().replace("-", "");
+        String key = KEY_PREFIX + token;
+        try {
+            redisTemplate.opsForValue().set(key, userId.toString(), TTL_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("SSE 토큰 저장 실패: {}", e.getMessage());
+            throw new RuntimeException("SSE 토큰 발급에 실패했습니다.");
+        }
+        return token;
+    }
+
+    public Optional<Long> consumeToken(String token) {
+        String key = KEY_PREFIX + token;
+        try {
+            String userId = redisTemplate.opsForValue().getAndDelete(key);
+            return Optional.ofNullable(userId).map(Long::parseLong);
+        } catch (Exception e) {
+            log.warn("SSE 토큰 조회 실패: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/consome/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/consome/infrastructure/security/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                         // Messages - all require auth
                         .requestMatchers("/api/v1/messages/**").authenticated()
 
-                        // Notifications - subscribe uses token param auth
+                        // Notifications - subscribe uses one-time SSE token (not JWT)
                         .requestMatchers(HttpMethod.GET, "/api/v1/notifications/subscribe").permitAll()
                         .requestMatchers("/api/v1/notifications/**").authenticated()
 

--- a/src/main/java/consome/interfaces/notification/v1/NotificationV1Controller.java
+++ b/src/main/java/consome/interfaces/notification/v1/NotificationV1Controller.java
@@ -14,6 +14,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.util.Map;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/notifications")
@@ -64,6 +66,13 @@ public class NotificationV1Controller {
             @AuthenticationPrincipal CustomUserDetails userDetails) {
         notificationFacade.deleteAll(userDetails.getUserId());
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/sse-token")
+    public ResponseEntity<Map<String, String>> createSseToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        String token = notificationFacade.createSseToken(userDetails.getUserId());
+        return ResponseEntity.ok(java.util.Map.of("token", token));
     }
 
     @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)


### PR DESCRIPTION
## Summary
- SSE 구독 시 JWT를 URL 쿼리 파라미터에 직접 전달하던 방식을 일회용 토큰 방식으로 변경
- `POST /notifications/sse-token` → 인증 후 랜덤 토큰 발급 (Redis TTL 30초)
- `GET /notifications/subscribe?token=` → Redis에서 토큰 소비(getAndDelete) 후 SSE 연결

## Why
- JWT가 서버 액세스 로그, 브라우저 히스토리, 프록시 로그에 평문으로 남는 보안 이슈
- EventSource API가 커스텀 헤더를 지원하지 않아 URL 파라미터를 사용할 수밖에 없는 제약 우회

## Changes
- **SseTokenRedisRepository**: `sse_token:` prefix, TTL 30초, UUID 토큰 생성/소비
- **NotificationFacade**: JwtProvider 의존 제거 → SseTokenRedisRepository로 교체
- **NotificationV1Controller**: `POST /sse-token` 엔드포인트 추가
- **SecurityConfig**: 주석 업데이트

## Test plan
- [ ] 로그인 후 SSE 연결 정상 동작 확인
- [ ] 동일 토큰으로 재연결 시 거부 확인 (일회용)
- [ ] 30초 후 토큰 만료 확인
- [ ] 재연결(에러 복구) 시 새 토큰 발급 후 연결 확인