### PR TITLE
fix: CORS 헤더 제한 및 HSTS 보안 헤더 추가

### DIFF
--- a/src/main/java/consome/infrastructure/security/SecurityConfig.java
+++ b/src/main/java/consome/infrastructure/security/SecurityConfig.java
@@ -45,6 +45,10 @@ public class SecurityConfig {
                         .frameOptions(frame -> frame.deny())
                         .contentTypeOptions(content -> {})
                         .cacheControl(cache -> {})
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .includeSubDomains(true)
+                                .maxAgeInSeconds(31536000)
+                        )
                 )
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session ->
@@ -107,6 +111,9 @@ public class SecurityConfig {
                 registry.addMapping("/**")
                         .allowedOrigins(allowedOrigins.split(","))
                         .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH")
+                        .allowedHeaders("Content-Type", "Authorization", "X-Requested-With")
+                        .exposedHeaders("Authorization")
+                        .maxAge(3600)
                         .allowCredentials(true);
             }
         };


### PR DESCRIPTION
## Summary
- CORS 설정에 allowedHeaders, exposedHeaders, maxAge 명시적 추가
- HSTS(HTTP Strict Transport Security) 헤더 추가

## Why
- CORS에 allowedHeaders 미설정 시 모든 헤더 허용 (보안 취약)
- maxAge 미설정 시 매 요청마다 preflight 발생 (성능)
- HSTS 미설정 시 HTTPS 다운그레이드 공격 가능

## Changes
- `allowedHeaders("Content-Type", "Authorization", "X-Requested-With")`
- `exposedHeaders("Authorization")`
- `maxAge(3600)` — preflight 캐시 1시간
- `httpStrictTransportSecurity` — maxAge 1년, includeSubDomains

## Note
- 기존 contentTypeOptions, cacheControl의 빈 람다(`content -> {}`)는 Spring Security 6 DSL에서 기본값 활성화를 의미하므로 정상 동작 확인됨