### PR TITLE
fix: Redis 캐시 record 역직렬화 오류 수정

### DIFF
--- a/src/main/java/consome/infrastructure/config/RedisConfig.java
+++ b/src/main/java/consome/infrastructure/config/RedisConfig.java
@@ -54,9 +54,10 @@ public class RedisConfig {
                         .allowIfSubType("consome.")
                         .allowIfSubType("java.util.")
                         .allowIfSubType("java.time.")
-                        .allowIfSubType("org.springframework.data.domain.")
+                        .allowIfSubType("java.lang.")
+                        .allowIfSubType("[L")
                         .build(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
+                ObjectMapper.DefaultTyping.EVERYTHING,
                 JsonTypeInfo.As.PROPERTY
         );
 


### PR DESCRIPTION
## Summary
- `DefaultTyping.NON_FINAL → EVERYTHING` 변경으로 Java record 타입 캐시 역직렬화 수정
- 타입 허용 범위에 `java.lang.*`, `[L`(배열) 추가
- `org.springframework.data.domain.*` 제거 (CachedPage 래퍼로 대체되어 불필요)

## 원인
`NON_FINAL`은 `final` 클래스에 `@class` 타입 정보를 포함하지 않음.
Java `record`는 암묵적으로 `final`이므로 `CachedPage`, `PopularPostResult`, `PopularBoardResult` 등의 캐시 직렬화/역직렬화가 실패.

이전 커밋 `a5fb6c3`에서 RCE 방지 목적으로 `EVERYTHING → NON_FINAL`로 변경했을 때 record 호환성이 누락된 것이 원인.

## 해결
- `EVERYTHING`으로 변경하여 record에도 `@class` 포함
- `allowIfSubType`으로 허용 타입 명시적 제한 유지 (보안)
  - `consome.*`, `java.util.*`, `java.time.*`, `java.lang.*`, `[L`(배열)

## 검증
- `popular-posts/paged`: 343개 정상 응답
- `popular-boards`: 3개 정상 응답
- `popular-posts`: 20개 정상 응답
- 캐시 히트(역직렬화): 정상
- 서버 재시작 후 데이터 유지: 정상
- 전체 테스트: BUILD SUCCESSFUL