### PR TITLE
feat: 실시간 검색어/시간대별 활동량 통계 기능

### DIFF
--- a/src/main/java/consome/application/board/BoardFacade.java
+++ b/src/main/java/consome/application/board/BoardFacade.java
@@ -14,6 +14,7 @@ import consome.domain.board.repository.BoardFavoriteRepository;
 import consome.domain.common.exception.BusinessException;
 import consome.domain.post.PostService;
 import consome.domain.post.PostSummary;
+import consome.domain.statistics.SearchStatService;
 import consome.domain.user.User;
 import consome.domain.user.UserService;
 import consome.infrastructure.redis.VisitedBoardRedisRepository;
@@ -40,6 +41,7 @@ public class BoardFacade {
     private final VisitedBoardRedisRepository visitedBoardRedisRepository;
     private final BoardFavoriteRepository boardFavoriteRepository;
     private final BoardRepository boardRepository;
+    private final SearchStatService searchStatService;
 
     public PostPagingResult getPosts(Long boardId, Pageable pageable, Long categoryId, Long userId, boolean popularOnly) {
         if (userId != null) {
@@ -110,8 +112,11 @@ public class BoardFacade {
         return boardService.searchByKeyword(keyword, limit);
     }
 
-    public PostPagingResult searchPosts(Long boardId, String keyword, String searchType, Pageable pageable) {
+    public PostPagingResult searchPosts(Long boardId, String keyword, String searchType, Pageable pageable,
+                                        Long requesterUserId, String requesterIp) {
         Board board = boardService.findById(boardId);
+
+        searchStatService.recordKeyword(keyword, requesterUserId, requesterIp);
 
         Page<PostSummary> page = postService.searchPosts(boardId, keyword, searchType, pageable);
 

--- a/src/main/java/consome/application/comment/CommentFacade.java
+++ b/src/main/java/consome/application/comment/CommentFacade.java
@@ -16,6 +16,8 @@ import consome.domain.post.PopularPostService;
 import consome.domain.post.PostService;
 import consome.domain.post.ReactionType;
 import consome.domain.post.entity.Post;
+import consome.domain.statistics.ActivityStatService;
+import consome.domain.statistics.ActivityType;
 import consome.domain.user.UserService;
 import consome.infrastructure.security.HtmlSanitizer;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +43,7 @@ public class CommentFacade {
     private final SectionService sectionService;
     private final NotificationFacade notificationFacade;
     private final HtmlSanitizer htmlSanitizer;
+    private final ActivityStatService activityStatService;
 
     @Transactional
     public CommentResult comment(Long postId, Long userId, Long parentId, String content) {
@@ -66,6 +69,7 @@ public class CommentFacade {
         // 알림 트리거
         sendCommentNotification(post, comment, userId, nickname, parentId);
 
+        activityStatService.recordActivity(ActivityType.COMMENT);
         return result;
     }
 
@@ -84,6 +88,7 @@ public class CommentFacade {
     public CommentStat like(Long commentId, Long userId) {
         CommentStat stat = commentService.like(commentId, userId);
         pointService.earn(userId, PointHistoryType.COMMENT_LIKE);
+        activityStatService.recordActivity(ActivityType.COMMENT_LIKE);
         return stat;
     }
 
@@ -91,6 +96,7 @@ public class CommentFacade {
     public CommentStat dislike(Long commentId, Long userId) {
         CommentStat stat = commentService.dislike(commentId, userId);
         pointService.penalize(userId, PointHistoryType.COMMENT_DISLIKE);
+        activityStatService.recordActivity(ActivityType.COMMENT_DISLIKE);
         return stat;
     }
 

--- a/src/main/java/consome/application/post/PostFacade.java
+++ b/src/main/java/consome/application/post/PostFacade.java
@@ -23,6 +23,8 @@ import consome.domain.post.repository.PostReactionRepository;
 import consome.domain.post.repository.PostVideoRepository;
 import consome.domain.post.repository.TempPostImageRepository;
 import consome.domain.post.repository.TempPostVideoRepository;
+import consome.domain.statistics.ActivityStatService;
+import consome.domain.statistics.ActivityType;
 import consome.domain.user.Role;
 import consome.domain.user.User;
 import consome.domain.user.UserService;
@@ -52,6 +54,7 @@ public class PostFacade {
     private final SectionService sectionService;
     private final UserService userService;
     private final HtmlSanitizer htmlSanitizer;
+    private final ActivityStatService activityStatService;
 
     @Transactional
     public PostResult post(PostCommand command) {
@@ -77,6 +80,7 @@ public class PostFacade {
             });
         }
 
+        activityStatService.recordActivity(ActivityType.POST);
         return PostResult.of(post.getId());
     }
 
@@ -109,6 +113,7 @@ public class PostFacade {
                 postImageRepository.save(postImage);
             }
         }
+        activityStatService.recordActivity(ActivityType.POST);
         return PostResult.of(post.getId());
 
     }
@@ -176,6 +181,7 @@ public class PostFacade {
         postService.like(post, userId);
         popularPostService.updateScore(post.getId());
 
+        activityStatService.recordActivity(ActivityType.POST_LIKE);
         return postService.getPostStat(post.getId());
     }
 
@@ -184,6 +190,7 @@ public class PostFacade {
         postService.dislike(post, userId);
         pointService.penalize(post.getUserId(), PointHistoryType.POST_DISLIKE);
 
+        activityStatService.recordActivity(ActivityType.POST_DISLIKE);
         return postService.getPostStat(post.getId());
     }
     public boolean hasLiked(Long postId, Long userId) {

--- a/src/main/java/consome/application/statistics/HourlyActivityResult.java
+++ b/src/main/java/consome/application/statistics/HourlyActivityResult.java
@@ -1,0 +1,21 @@
+package consome.application.statistics;
+
+import consome.domain.statistics.ActivityType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 시간대별 활동량 응답
+ * - days: 7 일 단위
+ * - type: 단일 타입(POST/COMMENT/...)이거나 ALL
+ * - rows: 날짜별 24시간 카운트 행
+ */
+public record HourlyActivityResult(
+        int days,
+        ActivityType type,
+        boolean aggregated,
+        List<DayRow> rows
+) {
+    public record DayRow(LocalDate date, long[] hours) {}
+}

--- a/src/main/java/consome/application/statistics/PopularKeywordResult.java
+++ b/src/main/java/consome/application/statistics/PopularKeywordResult.java
@@ -1,0 +1,3 @@
+package consome.application.statistics;
+
+public record PopularKeywordResult(int rank, String keyword, long count) {}

--- a/src/main/java/consome/application/statistics/StatisticsFacade.java
+++ b/src/main/java/consome/application/statistics/StatisticsFacade.java
@@ -2,20 +2,36 @@ package consome.application.statistics;
 
 import consome.domain.admin.Board;
 import consome.domain.admin.BoardService;
+import consome.domain.statistics.ActivityType;
 import consome.domain.statistics.StatisticsService;
+import consome.domain.statistics.entity.HourlyActivity;
+import consome.domain.statistics.repository.HourlyActivityRepository;
+import consome.infrastructure.redis.HourlyActivityRedisRepository;
+import consome.infrastructure.redis.SearchKeywordRedisRepository;
+import consome.infrastructure.redis.SearchKeywordRedisRepository.KeywordScore;
 import consome.infrastructure.redis.VisitedBoardRedisRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class StatisticsFacade {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final int MAX_KEYWORD_LIMIT = 50;
+
     private final StatisticsService statisticsService;
     private final VisitedBoardRedisRepository visitedBoardRedisRepository;
     private final BoardService boardService;
+    private final SearchKeywordRedisRepository searchKeywordRedisRepository;
+    private final HourlyActivityRedisRepository hourlyActivityRedisRepository;
+    private final HourlyActivityRepository hourlyActivityRepository;
 
     public AdminStatisticsResult getAdminStatistics() {
         return new AdminStatisticsResult(
@@ -47,5 +63,59 @@ public class StatisticsFacade {
         if (userId != null) {
             visitedBoardRedisRepository.recordVisit(userId, boardId);
         }
+    }
+
+    public List<PopularKeywordResult> getPopularKeywords(String period, int limit) {
+        String normalizedPeriod = "hour".equals(period) ? "hour" : "day";
+        int normalizedLimit = Math.min(Math.max(limit, 1), MAX_KEYWORD_LIMIT);
+
+        List<KeywordScore> scores = searchKeywordRedisRepository.getTopKeywords(normalizedPeriod, normalizedLimit);
+
+        List<PopularKeywordResult> result = new ArrayList<>(scores.size());
+        int rank = 1;
+        for (KeywordScore score : scores) {
+            result.add(new PopularKeywordResult(rank++, score.keyword(), score.count()));
+        }
+        return result;
+    }
+
+    public HourlyActivityResult getHourlyActivity(int days, String typeStr) {
+        int normalizedDays = Math.min(Math.max(days, 1), 30);
+        boolean aggregated = typeStr == null || "ALL".equalsIgnoreCase(typeStr);
+        ActivityType singleType = aggregated ? null : ActivityType.valueOf(typeStr.toUpperCase());
+
+        LocalDateTime now = LocalDateTime.now(KST);
+        LocalDate today = now.toLocalDate();
+        int currentHour = now.getHour();
+        LocalDate startDate = today.minusDays(normalizedDays - 1L);
+
+        // DB 누적 (이미 flush된 데이터)
+        long[][] matrix = new long[normalizedDays][24];
+        List<HourlyActivity> rows = aggregated
+                ? hourlyActivityRepository.findAllByDateRange(startDate, today)
+                : hourlyActivityRepository.findAllByDateRangeAndType(startDate, today, singleType);
+        for (HourlyActivity row : rows) {
+            int dayIdx = (int) (row.getActivityDate().toEpochDay() - startDate.toEpochDay());
+            if (dayIdx < 0 || dayIdx >= normalizedDays) continue;
+            int h = row.getHour();
+            if (h < 0 || h >= 24) continue;
+            matrix[dayIdx][h] += row.getCount();
+        }
+
+        // 미flush 보정: 오늘 currentHour 데이터를 Redis에서 조회
+        int todayIdx = normalizedDays - 1;
+        if (aggregated) {
+            for (ActivityType t : ActivityType.values()) {
+                matrix[todayIdx][currentHour] += hourlyActivityRedisRepository.getCount(t, today, currentHour);
+            }
+        } else {
+            matrix[todayIdx][currentHour] += hourlyActivityRedisRepository.getCount(singleType, today, currentHour);
+        }
+
+        List<HourlyActivityResult.DayRow> dayRows = new ArrayList<>(normalizedDays);
+        for (int i = 0; i < normalizedDays; i++) {
+            dayRows.add(new HourlyActivityResult.DayRow(startDate.plusDays(i), matrix[i]));
+        }
+        return new HourlyActivityResult(normalizedDays, singleType, aggregated, dayRows);
     }
 }

--- a/src/main/java/consome/domain/statistics/ActivityStatService.java
+++ b/src/main/java/consome/domain/statistics/ActivityStatService.java
@@ -1,0 +1,21 @@
+package consome.domain.statistics;
+
+import consome.infrastructure.redis.HourlyActivityRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ActivityStatService {
+
+    private final HourlyActivityRedisRepository hourlyActivityRedisRepository;
+
+    public void recordActivity(ActivityType type) {
+        if (type == null) return;
+        hourlyActivityRedisRepository.increment(type);
+    }
+
+    public void recordVisit() {
+        recordActivity(ActivityType.VISIT);
+    }
+}

--- a/src/main/java/consome/domain/statistics/ActivityType.java
+++ b/src/main/java/consome/domain/statistics/ActivityType.java
@@ -1,0 +1,11 @@
+package consome.domain.statistics;
+
+public enum ActivityType {
+    POST,
+    COMMENT,
+    POST_LIKE,
+    POST_DISLIKE,
+    COMMENT_LIKE,
+    COMMENT_DISLIKE,
+    VISIT
+}

--- a/src/main/java/consome/domain/statistics/SearchStatService.java
+++ b/src/main/java/consome/domain/statistics/SearchStatService.java
@@ -1,0 +1,33 @@
+package consome.domain.statistics;
+
+import consome.infrastructure.redis.SearchKeywordRedisRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+public class SearchStatService {
+
+    private static final int MAX_KEYWORD_LENGTH = 30;
+
+    private final SearchKeywordRedisRepository searchKeywordRedisRepository;
+
+    /**
+     * 검색 키워드 카운트
+     * - 정규화: trim + toLowerCase
+     * - 빈 값 / 30자 초과 → skip
+     * - dedupe 60s: (user:userId | ip:ip) + normalizedKeyword
+     */
+    public void recordKeyword(String keyword, Long userId, String ip) {
+        if (keyword == null) return;
+        String normalized = keyword.trim().toLowerCase(Locale.ROOT);
+        if (normalized.isEmpty() || normalized.length() > MAX_KEYWORD_LENGTH) return;
+
+        String requesterKey = userId != null ? "user:" + userId : "ip:" + ip;
+        if (!searchKeywordRedisRepository.markIfAbsent(requesterKey, normalized)) return;
+
+        searchKeywordRedisRepository.increment(normalized);
+    }
+}

--- a/src/main/java/consome/domain/statistics/entity/HourlyActivity.java
+++ b/src/main/java/consome/domain/statistics/entity/HourlyActivity.java
@@ -1,0 +1,55 @@
+package consome.domain.statistics.entity;
+
+import consome.domain.statistics.ActivityType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+    name = "hourly_activity",
+    uniqueConstraints = @UniqueConstraint(
+        name = "uk_hourly_activity_date_hour_type",
+        columnNames = {"activity_date", "hour", "type"}
+    ),
+    indexes = @Index(name = "idx_hourly_activity_date", columnList = "activity_date")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HourlyActivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "activity_date", nullable = false)
+    private LocalDate activityDate;
+
+    @Column(name = "hour", nullable = false)
+    private int hour;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 16)
+    private ActivityType type;
+
+    @Column(name = "count", nullable = false)
+    private long count;
+
+    private HourlyActivity(LocalDate activityDate, int hour, ActivityType type, long count) {
+        this.activityDate = activityDate;
+        this.hour = hour;
+        this.type = type;
+        this.count = count;
+    }
+
+    public static HourlyActivity of(LocalDate activityDate, int hour, ActivityType type, long count) {
+        return new HourlyActivity(activityDate, hour, type, count);
+    }
+
+    public void addCount(long delta) {
+        this.count += delta;
+    }
+}

--- a/src/main/java/consome/domain/statistics/repository/HourlyActivityRepository.java
+++ b/src/main/java/consome/domain/statistics/repository/HourlyActivityRepository.java
@@ -1,0 +1,32 @@
+package consome.domain.statistics.repository;
+
+import consome.domain.statistics.ActivityType;
+import consome.domain.statistics.entity.HourlyActivity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface HourlyActivityRepository extends JpaRepository<HourlyActivity, Long> {
+
+    Optional<HourlyActivity> findByActivityDateAndHourAndType(LocalDate activityDate, int hour, ActivityType type);
+
+    @Query("SELECT ha FROM HourlyActivity ha " +
+           "WHERE ha.activityDate >= :startDate AND ha.activityDate <= :endDate")
+    List<HourlyActivity> findAllByDateRange(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate
+    );
+
+    @Query("SELECT ha FROM HourlyActivity ha " +
+           "WHERE ha.activityDate >= :startDate AND ha.activityDate <= :endDate " +
+           "AND ha.type = :type")
+    List<HourlyActivity> findAllByDateRangeAndType(
+        @Param("startDate") LocalDate startDate,
+        @Param("endDate") LocalDate endDate,
+        @Param("type") ActivityType type
+    );
+}

--- a/src/main/java/consome/domain/statistics/repository/SiteVisitRepository.java
+++ b/src/main/java/consome/domain/statistics/repository/SiteVisitRepository.java
@@ -25,5 +25,5 @@ public interface SiteVisitRepository extends JpaRepository<SiteVisit, Long> {
     @Transactional
     @Modifying
     @Query(value = "INSERT IGNORE INTO site_visit (visitor_key, visit_date, first_visit_at) VALUES (:visitorKey, CURDATE(), NOW())", nativeQuery = true)
-    void insertIgnore(@Param("visitorKey") String visitorKey);
+    int insertIgnore(@Param("visitorKey") String visitorKey);
 }

--- a/src/main/java/consome/infrastructure/filter/OnlineTrackingFilter.java
+++ b/src/main/java/consome/infrastructure/filter/OnlineTrackingFilter.java
@@ -1,5 +1,6 @@
 package consome.infrastructure.filter;
 
+import consome.domain.statistics.ActivityStatService;
 import consome.domain.statistics.entity.SiteVisit;
 import consome.domain.statistics.repository.SiteVisitRepository;
 import consome.infrastructure.redis.OnlineUserRedisRepository;
@@ -24,6 +25,7 @@ public class OnlineTrackingFilter extends OncePerRequestFilter {
 
     private final OnlineUserRedisRepository onlineUserRedisRepository;
     private final SiteVisitRepository siteVisitRepository;
+    private final ActivityStatService activityStatService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -50,7 +52,12 @@ public class OnlineTrackingFilter extends OncePerRequestFilter {
 
         // DB: 일일 방문자 기록 (INSERT IGNORE로 race condition 방지)
         String visitorKey = SiteVisit.buildVisitorKey(userId, ip);
-        siteVisitRepository.insertIgnore(visitorKey);
+        int inserted = siteVisitRepository.insertIgnore(visitorKey);
+
+        // 신규 방문(하루 첫 진입)만 시간대별 VISIT 카운트
+        if (inserted > 0) {
+            activityStatService.recordVisit();
+        }
     }
 
     private Long extractUserId() {

--- a/src/main/java/consome/infrastructure/redis/HourlyActivityRedisRepository.java
+++ b/src/main/java/consome/infrastructure/redis/HourlyActivityRedisRepository.java
@@ -1,0 +1,114 @@
+package consome.infrastructure.redis;
+
+import consome.domain.statistics.ActivityType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class HourlyActivityRedisRepository {
+
+    private static final String KEY_PREFIX = "activity:";
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final long TTL_SECONDS = 172800; // 48시간 안전 마진
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * activity:{type}:{yyyymmdd}:{hour} INCR
+     */
+    public void increment(ActivityType type) {
+        LocalDateTime now = LocalDateTime.now(KST);
+        String key = buildKey(type, now.toLocalDate(), now.getHour());
+        try {
+            redisTemplate.opsForValue().increment(key);
+            redisTemplate.expire(key, TTL_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("activity increment failed ({}): {}", key, e.getMessage());
+        }
+    }
+
+    /**
+     * 특정 날짜/시간/타입 카운트 조회
+     */
+    public long getCount(ActivityType type, LocalDate date, int hour) {
+        String key = buildKey(type, date, hour);
+        try {
+            String value = redisTemplate.opsForValue().get(key);
+            return value == null ? 0L : Long.parseLong(value);
+        } catch (Exception e) {
+            log.warn("activity get failed ({}): {}", key, e.getMessage());
+            return 0L;
+        }
+    }
+
+    /**
+     * 스케줄러 flush 용 — 모든 activity:* 키 스캔
+     */
+    public List<FlushEntry> scanAll() {
+        List<FlushEntry> entries = new ArrayList<>();
+        try {
+            ScanOptions options = ScanOptions.scanOptions().match(KEY_PREFIX + "*").count(500).build();
+            try (Cursor<String> cursor = redisTemplate.scan(options)) {
+                while (cursor.hasNext()) {
+                    String key = cursor.next();
+                    FlushEntry entry = parseKey(key);
+                    if (entry == null) continue;
+                    String value = redisTemplate.opsForValue().get(key);
+                    if (value == null) continue;
+                    long count = Long.parseLong(value);
+                    entries.add(new FlushEntry(entry.type(), entry.date(), entry.hour(), count));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("activity scanAll failed: {}", e.getMessage());
+        }
+        return entries;
+    }
+
+    /**
+     * flush 완료 후 해당 키의 카운트만큼 차감 (누락 방지 — flush 중 추가 증분 보존)
+     */
+    public void decrement(ActivityType type, LocalDate date, int hour, long delta) {
+        String key = buildKey(type, date, hour);
+        try {
+            redisTemplate.opsForValue().decrement(key, delta);
+        } catch (Exception e) {
+            log.warn("activity decrement failed ({}): {}", key, e.getMessage());
+        }
+    }
+
+    private String buildKey(ActivityType type, LocalDate date, int hour) {
+        return KEY_PREFIX + type.name() + ":" + date.format(DATE_FMT) + ":" + hour;
+    }
+
+    private FlushEntry parseKey(String key) {
+        // activity:{TYPE}:{yyyymmdd}:{hour}
+        String[] parts = key.split(":");
+        if (parts.length != 4) return null;
+        try {
+            ActivityType type = ActivityType.valueOf(parts[1]);
+            LocalDate date = LocalDate.parse(parts[2], DATE_FMT);
+            int hour = Integer.parseInt(parts[3]);
+            return new FlushEntry(type, date, hour, 0L);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public record FlushEntry(ActivityType type, LocalDate date, int hour, long count) {}
+}

--- a/src/main/java/consome/infrastructure/redis/SearchKeywordRedisRepository.java
+++ b/src/main/java/consome/infrastructure/redis/SearchKeywordRedisRepository.java
@@ -1,0 +1,88 @@
+package consome.infrastructure.redis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class SearchKeywordRedisRepository {
+
+    private static final String HOUR_KEY = "search:rank:hour";
+    private static final String DAY_KEY = "search:rank:day";
+    private static final String DEDUPE_PREFIX = "search:dedupe:";
+    private static final long DEDUPE_TTL_SECONDS = 60;
+    private static final long HOUR_TTL_SECONDS = 7200;    // 2시간 안전 마진
+    private static final long DAY_TTL_SECONDS = 172800;   // 48시간 안전 마진
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    /**
+     * 중복 카운트 방지: 60초 이내 같은 (requester, keyword) 조합은 카운트 skip
+     * @return true = 신규(카운트 진행), false = 중복(skip)
+     */
+    public boolean markIfAbsent(String requesterKey, String normalizedKeyword) {
+        try {
+            String key = DEDUPE_PREFIX + requesterKey + ":" + normalizedKeyword;
+            Boolean set = redisTemplate.opsForValue()
+                    .setIfAbsent(key, "1", DEDUPE_TTL_SECONDS, TimeUnit.SECONDS);
+            return Boolean.TRUE.equals(set);
+        } catch (Exception e) {
+            log.warn("dedupe check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public void increment(String normalizedKeyword) {
+        try {
+            redisTemplate.opsForZSet().incrementScore(HOUR_KEY, normalizedKeyword, 1.0);
+            redisTemplate.expire(HOUR_KEY, HOUR_TTL_SECONDS, TimeUnit.SECONDS);
+
+            redisTemplate.opsForZSet().incrementScore(DAY_KEY, normalizedKeyword, 1.0);
+            redisTemplate.expire(DAY_KEY, DAY_TTL_SECONDS, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.warn("keyword increment failed: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * TOP N 조회
+     * @param period "hour" or "day"
+     */
+    public List<KeywordScore> getTopKeywords(String period, int limit) {
+        try {
+            String key = "hour".equals(period) ? HOUR_KEY : DAY_KEY;
+            Set<ZSetOperations.TypedTuple<String>> tuples =
+                    redisTemplate.opsForZSet().reverseRangeWithScores(key, 0, limit - 1);
+            if (tuples == null || tuples.isEmpty()) return Collections.emptyList();
+
+            return tuples.stream()
+                    .map(t -> new KeywordScore(t.getValue(), t.getScore() == null ? 0L : t.getScore().longValue()))
+                    .toList();
+        } catch (Exception e) {
+            log.warn("getTopKeywords failed: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * 일간 ZSET 초기화 (매일 00:00 KST 스케줄러에서 호출)
+     */
+    public void resetDay() {
+        try {
+            redisTemplate.delete(DAY_KEY);
+        } catch (Exception e) {
+            log.warn("resetDay failed: {}", e.getMessage());
+        }
+    }
+
+    public record KeywordScore(String keyword, long count) {}
+}

--- a/src/main/java/consome/infrastructure/scheduler/ActivityFlushScheduler.java
+++ b/src/main/java/consome/infrastructure/scheduler/ActivityFlushScheduler.java
@@ -1,0 +1,53 @@
+package consome.infrastructure.scheduler;
+
+import consome.domain.statistics.entity.HourlyActivity;
+import consome.domain.statistics.repository.HourlyActivityRepository;
+import consome.infrastructure.redis.HourlyActivityRedisRepository;
+import consome.infrastructure.redis.HourlyActivityRedisRepository.FlushEntry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ActivityFlushScheduler {
+
+    private final HourlyActivityRedisRepository hourlyActivityRedisRepository;
+    private final HourlyActivityRepository hourlyActivityRepository;
+
+    /**
+     * 매시간 정각 5분 후 — Redis 활동 카운트를 DB로 flush
+     * (정각 직후 발생한 활동까지 포함)
+     */
+    @Scheduled(cron = "0 5 * * * *")
+    @Transactional
+    public void flush() {
+        List<FlushEntry> entries = hourlyActivityRedisRepository.scanAll();
+        if (entries.isEmpty()) {
+            log.debug("hourly activity flush: no entries");
+            return;
+        }
+
+        long total = 0;
+        for (FlushEntry entry : entries) {
+            if (entry.count() <= 0) continue;
+
+            HourlyActivity row = hourlyActivityRepository
+                    .findByActivityDateAndHourAndType(entry.date(), entry.hour(), entry.type())
+                    .orElseGet(() -> hourlyActivityRepository.save(
+                            HourlyActivity.of(entry.date(), entry.hour(), entry.type(), 0L)));
+            row.addCount(entry.count());
+
+            // flush한 만큼만 차감 (flush 동안 추가 증분 보존)
+            hourlyActivityRedisRepository.decrement(entry.type(), entry.date(), entry.hour(), entry.count());
+            total += entry.count();
+        }
+
+        log.info("hourly activity flush: entries={}, total={}", entries.size(), total);
+    }
+}

--- a/src/main/java/consome/infrastructure/scheduler/SearchKeywordResetScheduler.java
+++ b/src/main/java/consome/infrastructure/scheduler/SearchKeywordResetScheduler.java
@@ -1,0 +1,24 @@
+package consome.infrastructure.scheduler;
+
+import consome.infrastructure.redis.SearchKeywordRedisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SearchKeywordResetScheduler {
+
+    private final SearchKeywordRedisRepository searchKeywordRedisRepository;
+
+    /**
+     * 매일 00:00 KST — 일간 인기 검색어 ZSET 초기화
+     */
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void resetDailyKeywords() {
+        searchKeywordRedisRepository.resetDay();
+        log.info("daily search keyword ZSET reset");
+    }
+}

--- a/src/main/java/consome/interfaces/board/v1/BoardV1Controller.java
+++ b/src/main/java/consome/interfaces/board/v1/BoardV1Controller.java
@@ -7,6 +7,7 @@ import consome.interfaces.admin.dto.CategoryResponse;
 import consome.interfaces.board.dto.BoardPostListResponse;
 import consome.interfaces.board.dto.BoardSearchResponse;
 import consome.interfaces.board.dto.FavoriteBoardResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -43,10 +44,22 @@ public class BoardV1Controller {
             @PathVariable Long boardId,
             @RequestParam String keyword,
             @RequestParam(defaultValue = "all") String type,
-            @PageableDefault(size = 20) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            HttpServletRequest request
     ) {
-        PostPagingResult result = boardFacade.searchPosts(boardId, keyword, type, pageable);
+        Long userId = userDetails != null ? userDetails.getUserId() : null;
+        String ip = extractClientIp(request);
+        PostPagingResult result = boardFacade.searchPosts(boardId, keyword, type, pageable, userId, ip);
         return ResponseEntity.ok(BoardPostListResponse.from(result));
+    }
+
+    private String extractClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isEmpty()) {
+            return xff.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
     }
 
     @GetMapping("/{boardId}/categories")

--- a/src/main/java/consome/interfaces/statistics/dto/HourlyActivityResponse.java
+++ b/src/main/java/consome/interfaces/statistics/dto/HourlyActivityResponse.java
@@ -1,0 +1,27 @@
+package consome.interfaces.statistics.dto;
+
+import consome.application.statistics.HourlyActivityResult;
+import consome.domain.statistics.ActivityType;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+public record HourlyActivityResponse(
+        int days,
+        ActivityType type,
+        boolean aggregated,
+        List<DayRow> rows
+) {
+    public record DayRow(LocalDate date, List<Long> hours) {}
+
+    public static HourlyActivityResponse from(HourlyActivityResult result) {
+        List<DayRow> rows = result.rows().stream()
+                .map(r -> new DayRow(
+                        r.date(),
+                        Arrays.stream(r.hours()).boxed().toList()
+                ))
+                .toList();
+        return new HourlyActivityResponse(result.days(), result.type(), result.aggregated(), rows);
+    }
+}

--- a/src/main/java/consome/interfaces/statistics/dto/PopularKeywordsResponse.java
+++ b/src/main/java/consome/interfaces/statistics/dto/PopularKeywordsResponse.java
@@ -1,0 +1,20 @@
+package consome.interfaces.statistics.dto;
+
+import consome.application.statistics.PopularKeywordResult;
+
+import java.util.List;
+
+public record PopularKeywordsResponse(
+        String period,
+        int limit,
+        List<Item> items
+) {
+    public record Item(int rank, String keyword, long count) {}
+
+    public static PopularKeywordsResponse of(String period, int limit, List<PopularKeywordResult> results) {
+        List<Item> items = results.stream()
+                .map(r -> new Item(r.rank(), r.keyword(), r.count()))
+                .toList();
+        return new PopularKeywordsResponse(period, limit, items);
+    }
+}

--- a/src/main/java/consome/interfaces/statistics/v1/StatisticsV1Controller.java
+++ b/src/main/java/consome/interfaces/statistics/v1/StatisticsV1Controller.java
@@ -1,16 +1,21 @@
 package consome.interfaces.statistics.v1;
 
+import consome.application.statistics.HourlyActivityResult;
+import consome.application.statistics.PopularKeywordResult;
 import consome.application.statistics.StatisticsFacade;
 import consome.application.statistics.VisitedBoardResult;
 import consome.infrastructure.security.CustomUserDetails;
 import consome.interfaces.statistics.dto.AdminStatisticsResponse;
+import consome.interfaces.statistics.dto.HourlyActivityResponse;
 import consome.interfaces.statistics.dto.OnlineCountResponse;
+import consome.interfaces.statistics.dto.PopularKeywordsResponse;
 import consome.interfaces.statistics.dto.VisitedBoardsResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -51,5 +56,29 @@ public class StatisticsV1Controller {
         }
         List<VisitedBoardResult> results = statisticsFacade.getVisitedBoards(userDetails.getUserId());
         return ResponseEntity.ok(VisitedBoardsResponse.from(results));
+    }
+
+    /**
+     * 인기 검색어 TOP N (공개)
+     */
+    @GetMapping("/statistics/popular-keywords")
+    public ResponseEntity<PopularKeywordsResponse> getPopularKeywords(
+            @RequestParam(defaultValue = "hour") String period,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        List<PopularKeywordResult> results = statisticsFacade.getPopularKeywords(period, limit);
+        return ResponseEntity.ok(PopularKeywordsResponse.of(period, limit, results));
+    }
+
+    /**
+     * 시간대별 활동량 히트맵 (관리자 전용)
+     */
+    @GetMapping("/admin/statistics/hourly-activity")
+    public ResponseEntity<HourlyActivityResponse> getHourlyActivity(
+            @RequestParam(defaultValue = "7") int days,
+            @RequestParam(defaultValue = "ALL") String type
+    ) {
+        HourlyActivityResult result = statisticsFacade.getHourlyActivity(days, type);
+        return ResponseEntity.ok(HourlyActivityResponse.from(result));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     password: ${DB_PASSWORD:consome}
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: false

--- a/src/test/java/consome/application/board/BoardFacadeIntegrationTest.java
+++ b/src/test/java/consome/application/board/BoardFacadeIntegrationTest.java
@@ -127,7 +127,7 @@ class BoardFacadeIntegrationTest {
             postFacade.post(PostCommand.of(boardId, categoryId, userId, "자바 기초", "다른 내용"));
 
             // when
-            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "title", pageable);
+            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "title", pageable, null, "127.0.0.1");
 
             // then
             assertThat(result.posts())
@@ -144,7 +144,7 @@ class BoardFacadeIntegrationTest {
             postFacade.post(PostCommand.of(boardId, categoryId, userId, "제목2", "JPA 기초"));
 
             // when
-            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "content", pageable);
+            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "content", pageable, null, "127.0.0.1");
 
             // then
             assertThat(result.posts())
@@ -163,7 +163,7 @@ class BoardFacadeIntegrationTest {
             commentService.comment(other.postId(), userId, null, "일반 댓글");
 
             // when
-            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "comment", pageable);
+            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "comment", pageable, null, "127.0.0.1");
 
             // then
             assertThat(result.posts())
@@ -182,7 +182,7 @@ class BoardFacadeIntegrationTest {
             commentService.comment(postWithComment.postId(), userId, null, uniqueKeyword + " 관련 댓글");
 
             // when
-            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "all", pageable);
+            PostPagingResult result = boardFacade.searchPosts(boardId, uniqueKeyword, "all", pageable, null, "127.0.0.1");
 
             // then
             assertThat(result.posts())
@@ -197,7 +197,7 @@ class BoardFacadeIntegrationTest {
             String nonExistKeyword = "절대없는키워드" + System.currentTimeMillis();
 
             // when
-            PostPagingResult result = boardFacade.searchPosts(boardId, nonExistKeyword, "all", pageable);
+            PostPagingResult result = boardFacade.searchPosts(boardId, nonExistKeyword, "all", pageable, null, "127.0.0.1");
 
             // then
             assertThat(result.posts()).isEmpty();

--- a/src/test/java/consome/application/statistics/StatisticsFacadeTest.java
+++ b/src/test/java/consome/application/statistics/StatisticsFacadeTest.java
@@ -1,0 +1,138 @@
+package consome.application.statistics;
+
+import consome.domain.admin.BoardService;
+import consome.domain.statistics.ActivityType;
+import consome.domain.statistics.StatisticsService;
+import consome.domain.statistics.entity.HourlyActivity;
+import consome.domain.statistics.repository.HourlyActivityRepository;
+import consome.infrastructure.redis.HourlyActivityRedisRepository;
+import consome.infrastructure.redis.SearchKeywordRedisRepository;
+import consome.infrastructure.redis.SearchKeywordRedisRepository.KeywordScore;
+import consome.infrastructure.redis.VisitedBoardRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsFacadeTest {
+
+    @Mock private StatisticsService statisticsService;
+    @Mock private VisitedBoardRedisRepository visitedBoardRedisRepository;
+    @Mock private BoardService boardService;
+    @Mock private SearchKeywordRedisRepository searchKeywordRedisRepository;
+    @Mock private HourlyActivityRedisRepository hourlyActivityRedisRepository;
+    @Mock private HourlyActivityRepository hourlyActivityRepository;
+
+    @InjectMocks private StatisticsFacade statisticsFacade;
+
+    @Test
+    void getPopularKeywords_TOP_N_조회_rank_부여() {
+        when(searchKeywordRedisRepository.getTopKeywords("hour", 10))
+                .thenReturn(List.of(
+                        new KeywordScore("java", 50L),
+                        new KeywordScore("python", 30L),
+                        new KeywordScore("vue", 10L)
+                ));
+
+        List<PopularKeywordResult> result = statisticsFacade.getPopularKeywords("hour", 10);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).rank()).isEqualTo(1);
+        assertThat(result.get(0).keyword()).isEqualTo("java");
+        assertThat(result.get(0).count()).isEqualTo(50L);
+        assertThat(result.get(1).rank()).isEqualTo(2);
+        assertThat(result.get(2).rank()).isEqualTo(3);
+    }
+
+    @Test
+    void getPopularKeywords_빈_결과_빈_목록_반환() {
+        when(searchKeywordRedisRepository.getTopKeywords(anyString(), anyInt()))
+                .thenReturn(List.of());
+
+        List<PopularKeywordResult> result = statisticsFacade.getPopularKeywords("day", 10);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getHourlyActivity_단일_타입_조회_DB_누적_Redis_현재시간_합산() {
+        ActivityType type = ActivityType.POST;
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+
+        when(hourlyActivityRepository.findAllByDateRangeAndType(any(), any(), any()))
+                .thenReturn(List.of(
+                        HourlyActivity.of(yesterday, 10, type, 5L),
+                        HourlyActivity.of(today, 9, type, 3L)
+                ));
+        when(hourlyActivityRedisRepository.getCount(any(), any(), anyInt()))
+                .thenReturn(0L);
+
+        HourlyActivityResult result = statisticsFacade.getHourlyActivity(7, "POST");
+
+        assertThat(result.days()).isEqualTo(7);
+        assertThat(result.type()).isEqualTo(ActivityType.POST);
+        assertThat(result.aggregated()).isFalse();
+        assertThat(result.rows()).hasSize(7);
+        assertThat(result.rows().get(0).date()).isEqualTo(today.minusDays(6));
+        assertThat(result.rows().get(6).date()).isEqualTo(today);
+
+        // yesterday는 today 직전 인덱스
+        long[] yesterdayHours = result.rows().get(5).hours();
+        assertThat(yesterdayHours).hasSize(24);
+        assertThat(yesterdayHours[10]).isEqualTo(5L);
+
+        long[] todayHours = result.rows().get(6).hours();
+        assertThat(todayHours[9]).isEqualTo(3L);
+    }
+
+    @Test
+    void getHourlyActivity_ALL_타입은_aggregated_true_모든_타입_합산() {
+        LocalDate today = LocalDate.now();
+
+        when(hourlyActivityRepository.findAllByDateRange(any(), any()))
+                .thenReturn(List.of(
+                        HourlyActivity.of(today, 5, ActivityType.POST, 2L),
+                        HourlyActivity.of(today, 5, ActivityType.COMMENT, 3L),
+                        HourlyActivity.of(today, 5, ActivityType.VISIT, 100L)
+                ));
+        when(hourlyActivityRedisRepository.getCount(any(), any(), anyInt()))
+                .thenReturn(0L);
+
+        HourlyActivityResult result = statisticsFacade.getHourlyActivity(1, "ALL");
+
+        assertThat(result.aggregated()).isTrue();
+        assertThat(result.type()).isNull();
+        assertThat(result.rows()).hasSize(1);
+        assertThat(result.rows().get(0).hours()[5]).isEqualTo(105L);
+    }
+
+    @Test
+    void getHourlyActivity_Redis_현재시간_미flush_데이터_합산() {
+        ActivityType type = ActivityType.POST;
+        LocalDate today = LocalDate.now();
+        int currentHour = java.time.LocalDateTime.now(java.time.ZoneId.of("Asia/Seoul")).getHour();
+
+        when(hourlyActivityRepository.findAllByDateRangeAndType(any(), any(), any()))
+                .thenReturn(List.of());
+        when(hourlyActivityRedisRepository.getCount(any(), any(), anyInt()))
+                .thenReturn(0L);
+        when(hourlyActivityRedisRepository.getCount(type, today, currentHour))
+                .thenReturn(7L);
+
+        HourlyActivityResult result = statisticsFacade.getHourlyActivity(1, "POST");
+
+        assertThat(result.rows().get(0).hours()[currentHour]).isEqualTo(7L);
+    }
+}

--- a/src/test/java/consome/domain/statistics/ActivityStatServiceTest.java
+++ b/src/test/java/consome/domain/statistics/ActivityStatServiceTest.java
@@ -1,0 +1,56 @@
+package consome.domain.statistics;
+
+import consome.infrastructure.redis.HourlyActivityRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityStatServiceTest {
+
+    @Mock
+    private HourlyActivityRedisRepository hourlyActivityRedisRepository;
+
+    @InjectMocks
+    private ActivityStatService activityStatService;
+
+    @Test
+    void recordActivity_POST_호출시_POST_증분() {
+        activityStatService.recordActivity(ActivityType.POST);
+        verify(hourlyActivityRedisRepository).increment(ActivityType.POST);
+    }
+
+    @Test
+    void recordActivity_COMMENT_호출시_COMMENT_증분() {
+        activityStatService.recordActivity(ActivityType.COMMENT);
+        verify(hourlyActivityRedisRepository).increment(ActivityType.COMMENT);
+    }
+
+    @Test
+    void recordActivity_LIKE_DISLIKE_VISIT_각각_증분() {
+        activityStatService.recordActivity(ActivityType.LIKE);
+        activityStatService.recordActivity(ActivityType.DISLIKE);
+        activityStatService.recordActivity(ActivityType.VISIT);
+
+        verify(hourlyActivityRedisRepository).increment(ActivityType.LIKE);
+        verify(hourlyActivityRedisRepository).increment(ActivityType.DISLIKE);
+        verify(hourlyActivityRedisRepository).increment(ActivityType.VISIT);
+    }
+
+    @Test
+    void recordActivity_null이면_skip() {
+        activityStatService.recordActivity(null);
+        verify(hourlyActivityRedisRepository, never()).increment(null);
+    }
+
+    @Test
+    void recordVisit_VISIT_증분_별칭() {
+        activityStatService.recordVisit();
+        verify(hourlyActivityRedisRepository).increment(ActivityType.VISIT);
+    }
+}

--- a/src/test/java/consome/domain/statistics/SearchStatServiceTest.java
+++ b/src/test/java/consome/domain/statistics/SearchStatServiceTest.java
@@ -1,0 +1,97 @@
+package consome.domain.statistics;
+
+import consome.infrastructure.redis.SearchKeywordRedisRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SearchStatServiceTest {
+
+    @Mock
+    private SearchKeywordRedisRepository searchKeywordRedisRepository;
+
+    @InjectMocks
+    private SearchStatService searchStatService;
+
+    @Test
+    void recordKeyword_정상_키워드_정규화후_카운트() {
+        when(searchKeywordRedisRepository.markIfAbsent(anyString(), anyString())).thenReturn(true);
+
+        searchStatService.recordKeyword("  Hello World  ", 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository).markIfAbsent("user:1", "hello world");
+        verify(searchKeywordRedisRepository).increment("hello world");
+    }
+
+    @Test
+    void recordKeyword_userId_null이면_ip로_dedupe_키_구성() {
+        when(searchKeywordRedisRepository.markIfAbsent(anyString(), anyString())).thenReturn(true);
+
+        searchStatService.recordKeyword("java", null, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository).markIfAbsent("ip:1.2.3.4", "java");
+        verify(searchKeywordRedisRepository).increment("java");
+    }
+
+    @Test
+    void recordKeyword_빈_값_skip() {
+        searchStatService.recordKeyword("   ", 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository, never()).markIfAbsent(anyString(), anyString());
+        verify(searchKeywordRedisRepository, never()).increment(anyString());
+    }
+
+    @Test
+    void recordKeyword_null_skip() {
+        searchStatService.recordKeyword(null, 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository, never()).markIfAbsent(anyString(), anyString());
+        verify(searchKeywordRedisRepository, never()).increment(anyString());
+    }
+
+    @Test
+    void recordKeyword_30자_초과_skip() {
+        String over = "a".repeat(31);
+
+        searchStatService.recordKeyword(over, 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository, never()).markIfAbsent(anyString(), anyString());
+        verify(searchKeywordRedisRepository, never()).increment(anyString());
+    }
+
+    @Test
+    void recordKeyword_정확히_30자_카운트_허용() {
+        String exact = "a".repeat(30);
+        when(searchKeywordRedisRepository.markIfAbsent(anyString(), anyString())).thenReturn(true);
+
+        searchStatService.recordKeyword(exact, 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository).increment(exact);
+    }
+
+    @Test
+    void recordKeyword_dedupe_중복시_increment_skip() {
+        when(searchKeywordRedisRepository.markIfAbsent(anyString(), anyString())).thenReturn(false);
+
+        searchStatService.recordKeyword("java", 1L, "1.2.3.4");
+
+        verify(searchKeywordRedisRepository).markIfAbsent("user:1", "java");
+        verify(searchKeywordRedisRepository, never()).increment(anyString());
+    }
+
+    @Test
+    void recordKeyword_requester_구분_없이_IP만_있으면_IP로() {
+        when(searchKeywordRedisRepository.markIfAbsent(eq("ip:9.9.9.9"), anyString())).thenReturn(true);
+
+        searchStatService.recordKeyword("python", null, "9.9.9.9");
+
+        verify(searchKeywordRedisRepository).increment("python");
+    }
+}

--- a/src/test/java/consome/interfaces/statistics/v1/StatisticsV1ControllerE2eTest.java
+++ b/src/test/java/consome/interfaces/statistics/v1/StatisticsV1ControllerE2eTest.java
@@ -1,0 +1,142 @@
+package consome.interfaces.statistics.v1;
+
+import consome.application.user.UserFacade;
+import consome.application.user.UserLoginCommand;
+import consome.application.user.UserLoginResult;
+import consome.application.user.UserRegisterCommand;
+import consome.domain.email.EmailVerificationService;
+import consome.domain.user.Role;
+import consome.domain.user.User;
+import consome.domain.user.UserRepository;
+import consome.infrastructure.mail.EmailService;
+import consome.interfaces.statistics.dto.HourlyActivityResponse;
+import consome.interfaces.statistics.dto.PopularKeywordsResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestcontainersConfiguration.class)
+@ActiveProfiles("test")
+class StatisticsV1ControllerE2eTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private UserFacade userFacade;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockBean
+    private EmailService emailService;
+
+    @MockBean
+    private EmailVerificationService emailVerificationService;
+
+    private HttpHeaders adminAuthHeaders() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String loginId = "admin" + suffix;
+        String password = "Password123";
+        userFacade.registerWithoutEmail(
+                UserRegisterCommand.of(loginId, "admin" + suffix, password, loginId + "@test.com")
+        );
+        User user = userRepository.findByLoginId(loginId).orElseThrow();
+        user.updateRole(Role.ADMIN);
+        userRepository.save(user);
+
+        UserLoginResult login = userFacade.login(new UserLoginCommand(loginId, password));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(login.accessToken());
+        return headers;
+    }
+
+    @Test
+    @DisplayName("인기 검색어 - 기본 파라미터로 200 응답 (빈 결과 허용)")
+    void getPopularKeywords_default() {
+        ResponseEntity<PopularKeywordsResponse> response = restTemplate.getForEntity(
+                "/api/v1/statistics/popular-keywords",
+                PopularKeywordsResponse.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().period()).isEqualTo("hour");
+        assertThat(response.getBody().limit()).isEqualTo(10);
+        assertThat(response.getBody().items()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("인기 검색어 - period=day, limit=5 파라미터 반영")
+    void getPopularKeywords_dayLimit5() {
+        ResponseEntity<PopularKeywordsResponse> response = restTemplate.getForEntity(
+                "/api/v1/statistics/popular-keywords?period=day&limit=5",
+                PopularKeywordsResponse.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().period()).isEqualTo("day");
+        assertThat(response.getBody().limit()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("시간대별 활동량 - 관리자 인증 시 기본 파라미터: 7일 ALL 집계")
+    void getHourlyActivity_default() {
+        ResponseEntity<HourlyActivityResponse> response = restTemplate.exchange(
+                "/api/v1/admin/statistics/hourly-activity",
+                HttpMethod.GET,
+                new HttpEntity<>(adminAuthHeaders()),
+                HourlyActivityResponse.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().days()).isEqualTo(7);
+        assertThat(response.getBody().aggregated()).isTrue();
+        assertThat(response.getBody().rows()).hasSize(7);
+        assertThat(response.getBody().rows().get(0).hours()).hasSize(24);
+    }
+
+    @Test
+    @DisplayName("시간대별 활동량 - 단일 타입 지정 시 aggregated=false")
+    void getHourlyActivity_singleType() {
+        ResponseEntity<HourlyActivityResponse> response = restTemplate.exchange(
+                "/api/v1/admin/statistics/hourly-activity?days=3&type=POST",
+                HttpMethod.GET,
+                new HttpEntity<>(adminAuthHeaders()),
+                HourlyActivityResponse.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().days()).isEqualTo(3);
+        assertThat(response.getBody().aggregated()).isFalse();
+        assertThat(response.getBody().rows()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("히트맵은 비인증 호출 시 차단 (401 또는 403)")
+    void unauthorized_blocked() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "/api/v1/admin/statistics/hourly-activity",
+                String.class
+        );
+        assertThat(response.getStatusCode().value()).isIn(401, 403);
+    }
+}


### PR DESCRIPTION
## Summary
- 인기 검색어 Redis ZSET 기반 집계 + 공개 API (`/statistics/popular-keywords`)
- 시간대별 활동량 히트맵 관리자 전용 API (`/admin/statistics/hourly-activity`)
- ActivityType 세분화 (POST / COMMENT / POST_LIKE / POST_DISLIKE / COMMENT_LIKE / COMMENT_DISLIKE / VISIT)
- OnlineTrackingFilter 신규 방문자만 VISIT 카운트(insertIgnore affected rows 기준)

## 주요 변경
### 통계 도메인 신설
- `HourlyActivity` 엔티티 + `HourlyActivityRepository`
- `ActivityStatService` / `SearchStatService`
- `HourlyActivityRedisRepository` / `SearchKeywordRedisRepository`
- `ActivityFlushScheduler` (시간별 Redis → DB flush)
- `SearchKeywordResetScheduler` (기간별 ZSET 리셋)

### 집계 포인트 연결
- `PostFacade.like/dislike` → `POST_LIKE` / `POST_DISLIKE`
- `CommentFacade.like/dislike` → `COMMENT_LIKE` / `COMMENT_DISLIKE`
- `PostFacade.post` → `POST`, `CommentFacade.comment` → `COMMENT`
- `OnlineTrackingFilter` → `VISIT` (신규 일일 방문일 때만)

### API 인터페이스
- `/api/v1/statistics/popular-keywords` (공개)
- `/api/v1/admin/statistics/hourly-activity` (ADMIN/MANAGER)
- `PopularKeywordsResponse`, `HourlyActivityResponse` DTO

## 테스트
- `ActivityStatServiceTest` / `SearchStatServiceTest` 단위 테스트
- `StatisticsFacadeTest` 통합 테스트
- `StatisticsV1ControllerE2eTest` (공개/관리자 인증 분리 검증)

## 영향 범위
- 공개 엔드포인트 1개 추가, 관리자 엔드포인트 1개 추가
- `hourly_activity` 테이블 신규 생성(ddl-auto update)
- Redis 키 네임스페이스 신규: `activity:*`, `search:*`

## Test plan
- [ ] `./gradlew test` 전체 통과
- [ ] 게시글/댓글 추천·비추 시 `hourly_activity` 해당 타입 카운트 증가
- [ ] 방문 시 동일 사용자 재요청은 VISIT 카운트 증가하지 않음(하루 첫 진입만)
- [ ] 공개 URL 비인증 호출 200, 관리자 URL 비인증 호출 403